### PR TITLE
Fix for non-tiff

### DIFF
--- a/main.R
+++ b/main.R
@@ -26,6 +26,13 @@ doc_to_data <- function(df){
   f.names <- tim::load_data(ctx, docId, force_load=FALSE)
   f.names <- grep('*/ImageResults/*', f.names, value = TRUE )
   
+  inc_files <- unlist(lapply(f.names, function(x){
+    str_to_lower(file_ext(x)) %in% c("tif", "tiff")
+  }))
+  
+  
+  f.names <- f.names[inc_files]
+  
   # read tags
   result <- do.call(rbind, lapply(f.names, FUN = function(filename) {
     tags <- get_file_tags(filename)

--- a/main.R
+++ b/main.R
@@ -2,6 +2,7 @@ library(tercen)
 library(dplyr)
 library(ijtiff)
 library(stringr)  
+library(tools)
 
 TAG_LIST  <- list("date_time" = "DateTime", "barcode" = "Barcode", "col" = "Col", "cycle" = "Cycle", "exposure time" = "Exposure Time", "filter" = "Filter", 
                   "ps12" = "PS12", "row" = "Row", "temperature" = "Temperature", "timestamp" = "Timestamp", "instrument unit" = "Instrument Unit", "run id" = "RunId")

--- a/main.R
+++ b/main.R
@@ -1,6 +1,7 @@
 library(tercen)
 library(dplyr)
 library(ijtiff)
+library(stringr)  
 
 TAG_LIST  <- list("date_time" = "DateTime", "barcode" = "Barcode", "col" = "Col", "cycle" = "Cycle", "exposure time" = "Exposure Time", "filter" = "Filter", 
                   "ps12" = "PS12", "row" = "Row", "temperature" = "Temperature", "timestamp" = "Timestamp", "instrument unit" = "Instrument Unit", "run id" = "RunId")


### PR DESCRIPTION
This pull request fixes the issue when the zip file contains other than tiff images (non-tiff are filtered out). 